### PR TITLE
Change dist on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-# http://conda.pydata.org/docs/travis.html
+dist: xenial  # Required for Python >= 3.7
+
 language: python
 
 matrix:
   include:
-    - python: 3.6  # => 3.7
+    - name: "Channel `defaults`; jitted"
+      python: 3.7
       env: PYTHON=3.7 PCKGS="mkl mkl-service numba" CHAN="defaults" INST=""
-    - python: 3.6  # => 3.7 with conda-forge; IPython, discretize, no JIT
+    - name: "Channel `conda-forge`; not jitted"
+      python: 3.7
       env: PYTHON=3.7 PCKGS="numba IPython" NUMBA_DISABLE_JIT=1 CHAN="conda-forge" INST="discretize"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: xenial  # Required for Python >= 3.7
 
 language: python
 
+# Note: the -python flag in the matrix has no influence, as we use miniconda to
+# install Python, which uses the env-variable PYTHON. Having it here is just
+# bookkeeping, so it prints the same version in the Travis info.
 matrix:
   include:
     - python: 3.7  # => 3.7 with defaults; mkl

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ language: python
 
 matrix:
   include:
-    - name: "Channel `defaults`; jitted"
-      python: 3.7
+    - python: 3.7  # => 3.7 with defaults; mkl
       env: PYTHON=3.7 PCKGS="mkl mkl-service numba" CHAN="defaults" INST=""
-    - name: "Channel `conda-forge`; not jitted"
-      python: 3.7
+    - python: 3.7  # => 3.7 with conda-forge; IPython, discretize, no JIT
       env: PYTHON=3.7 PCKGS="numba IPython" NUMBA_DISABLE_JIT=1 CHAN="conda-forge" INST="discretize"
 
 install:


### PR DESCRIPTION
Change dist on Travis. This way we can use the Python version 3.7, which will display the correct version on the Travis page. However, this is purely cosmetic, as we don't actually use the Travis Python version, but miniconda.