### PR TITLE
Replace RegularGridInterpolator

### DIFF
--- a/emg3d/njitted.py
+++ b/emg3d/njitted.py
@@ -2137,3 +2137,45 @@ def prolong_init(xy, xi):
         norm_distances[:, i] = normd
 
     return indices, norm_distances
+
+
+@nb.njit(**_numba_setting)
+def prolon_fx(vectorNy, vectorNz, cefieldx, yz_points):
+    """Bilinear interpolation in the y-z plane.
+
+    Prolongate the x-directed e-field by looping over each x-slice,
+    interpolating the y-z-plane.
+
+
+    Parameters
+    ----------
+    vectorNy, vectorNz : ndarray
+        Cell edges of the coarse grid in y- and z-directions.
+
+    cefieldx : ndarray
+        Coarse grid electric x-directed field.
+
+    yz_points : ndarray
+        2D array containing the (y, z)-coordinates to interpolate.
+
+
+    Returns
+    -------
+    efieldx : ndarray
+        Fine grid electric x-directed field.
+
+    """
+    # Number of x-slices.
+    nCx = cefieldx.shape[0]
+
+    # Pre-allocate interpolated field.
+    efieldx = np.zeros((nCx, yz_points.shape[0]), dtype=np.complex128)
+
+    # Initialize interpolation.
+    rgi_inp = prolong_init((vectorNy, vectorNz), yz_points)
+
+    # Bilinear interpolation for each y-z-plane/x-slice.
+    for ixc in range(nCx):
+        efieldx[ixc, :] = prolong(cefieldx[ixc, :, :], *rgi_inp)
+
+    return efieldx

--- a/emg3d/njitted.py
+++ b/emg3d/njitted.py
@@ -2179,3 +2179,87 @@ def prolon_fx(vectorNy, vectorNz, cefieldx, yz_points):
         efieldx[ixc, :] = prolong(cefieldx[ixc, :, :], *rgi_inp)
 
     return efieldx
+
+
+@nb.njit(**_numba_setting)
+def prolon_fy(vectorNx, vectorNz, cefieldy, xz_points):
+    """Bilinear interpolation in the x-z plane.
+
+    Prolongate the y-directed e-field by looping over each y-slice,
+    interpolating the x-z-plane.
+
+
+    Parameters
+    ----------
+    vectorNx, vectorNz : ndarray
+        Cell edges of the coarse grid in x- and z-directions.
+
+    cefieldy : ndarray
+        Coarse grid electric y-directed field.
+
+    xz_points : ndarray
+        2D array containing the (x, z)-coordinates to interpolate.
+
+
+    Returns
+    -------
+    efieldy : ndarray
+        Fine grid electric y-directed field.
+
+    """
+    # Number of y-slices.
+    nCy = cefieldy.shape[1]
+
+    # Pre-allocate interpolated field.
+    efieldy = np.zeros((nCy, xz_points.shape[0]), dtype=np.complex128)
+
+    # Initialize interpolation.
+    rgi_inp = prolong_init((vectorNx, vectorNz), xz_points)
+
+    # Bilinear interpolation for each x-z-plane/y-slice.
+    for iyc in range(nCy):
+        efieldy[iyc, :] = prolong(cefieldy[:, iyc, :], *rgi_inp)
+
+    return efieldy
+
+
+@nb.njit(**_numba_setting)
+def prolon_fz(vectorNx, vectorNy, cefieldz, xy_points):
+    """Bilinear interpolation in the x-y plane.
+
+    Prolongate the z-directed e-field by looping over each z-slice,
+    interpolating the x-y-plane.
+
+
+    Parameters
+    ----------
+    vectorNx, vectorNy : ndarray
+        Cell edges of the coarse grid in x- and y-directions.
+
+    cefieldz : ndarray
+        Coarse grid electric z-directed field.
+
+    xy_points : ndarray
+        2D array containing the (x, y)-coordinates to interpolate.
+
+
+    Returns
+    -------
+    efieldz : ndarray
+        Fine grid electric z-directed field.
+
+    """
+    # Number of z-slices.
+    nCz = cefieldz.shape[2]
+
+    # Pre-allocate interpolated field.
+    efieldz = np.zeros((nCz, xy_points.shape[0]), dtype=np.complex128)
+
+    # Initialize interpolation.
+    rgi_inp = prolong_init((vectorNx, vectorNy), xy_points)
+
+    # Bilinear interpolation for each x-y-plane/z-slice.
+    for izc in range(nCz):
+        efieldz[izc, :] = prolong(cefieldz[:, :, izc], *rgi_inp)
+
+    return efieldz

--- a/emg3d/njitted.py
+++ b/emg3d/njitted.py
@@ -2040,7 +2040,8 @@ def prolong(cefield, indices, norm_distances):
     - ``fill_value=None``;
     - changes in order to jitt it;
     - re-arrangement so only the necessary things have to be done inside the
-      loop in :func:`emg3d.solver.prolongation`.
+      loop in :func:`emg3d.solver.prolongation`;
+    - No sanity checks are carried out; the input must be as expected.
 
 
     Parameters

--- a/tests/test_njitted.py
+++ b/tests/test_njitted.py
@@ -340,16 +340,16 @@ def test_prolong():
         fn = si.RegularGridInterpolator(
                 (cgrid.vectorNy, cgrid.vectorNz), cefield.fx[ixc, :, :],
                 bounds_error=False, fill_value=None)
-        hh = fn(yz_points)
-        hh = fn(yz_points).reshape(grid.vnEx[1:], order='F')
+        efieldx = fn(yz_points)
+        efieldx = fn(yz_points).reshape(grid.vnEx[1:], order='F')
 
         # Piecewise constant interpolation in x-direction
-        efield1.fx[2*ixc, :, :] += hh
-        efield1.fx[2*ixc+1, :, :] += hh
+        efield1.fx[2*ixc, :, :] += efieldx
+        efield1.fx[2*ixc+1, :, :] += efieldx
 
     # Calculate emg3d-version:
-    efieldx = njitted.prolon_fx(
-            cgrid.vectorNy, cgrid.vectorNz, cefield.fx, yz_points)
+    efieldx = njitted.prolong_field(
+            cgrid.vectorNy, cgrid.vectorNz, cefield.fx, yz_points, cgrid.nCx)
 
     # Change sorting from C- to F-order.
     # (Not yet possible in numba; move everything njitted once possible).


### PR DESCRIPTION
Replace `scipy.interpolate.RegularGridInterpolator` with a custom version of it, jitted.

This can speed-up the prolongation massively for small grids (up to 10 times faster) and moderately for huge grids (1.15 times faster), which in turns speeds-up the entire multigrid solver. However, this is only visible if MG is used as a solver, not as a pre-conditioner.

The customization makes the following assumption and adjustments:
    - Only supports 2D;
    - ``bounds_error=False``;
    - ``fill_value=None``;
    - changes in order to jitt it;
    - re-arrangement so only the necessary things have to be done inside the loop in `emg3d.solver.prolongation`;
    - No sanity checks are carried out; the input must be as expected.
    - Interpolated field is directly put into the provided efield.