### PR TITLE
Use `scooby` for `Versions`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ language: python
 # bookkeeping, so it prints the same version in the Travis info.
 matrix:
   include:
-    - python: 3.7  # => 3.7 with conda-forge; IPython, discretize, no JIT
-      env: PYTHON=3.7 PCKGS="numba IPython" NUMBA_DISABLE_JIT=1 CHAN="conda-forge" INST="discretize"
-    - python: 3.7  # => 3.7 with defaults; mkl
-      env: PYTHON=3.7 PCKGS="mkl mkl-service numba" CHAN="defaults" INST=""
+    - python: 3.7  # => 3.7 no JIT
+      env: PYTHON=3.7 NUMBA_DISABLE_JIT=1
+    - python: 3.7  # => 3.7
+      env: PYTHON=3.7
 
 install:
   - sudo apt-get update
@@ -26,9 +26,9 @@ install:
   - conda info -a
 
   # Install and activate environment, install packages
-  - conda create -q -n test-environment -c $CHAN python=$PYTHON numpy scipy pytest pytest-cov $PCKGS
-  - source activate test-environment
-  - pip install coveralls pytest-flake8 scooby $INST
+  - conda create -q -n tenv python=$PYTHON numpy scipy pytest pytest-cov numba
+  - source activate tenv
+  - pip install coveralls pytest-flake8 scooby
   - python setup.py install
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # Install and activate environment, install packages
   - conda create -q -n test-environment -c $CHAN python=$PYTHON numpy scipy pytest pytest-cov $PCKGS
   - source activate test-environment
-  - pip install coveralls pytest-flake8 $INST
+  - pip install coveralls pytest-flake8 scooby $INST
   - python setup.py install
 
 

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1407,6 +1407,45 @@ def data_read(fname, keys=None, path="data"):
 
 # OTHER
 class Versions(scooby.Report):
+    r"""Print date, time, and version information.
+
+    Use scooby to print date, time, and package version information in any
+    environment (Jupyter notebook, IPython console, Python console, QT
+    console), either as html-table (notebook) or as plain text (anywhere).
+
+    Always shown are the OS, number of CPU(s), ``numpy``, ``scipy``, ``emg3d``,
+    ``numba``, ``sys.version``, and time/date.
+
+    Additionally shown are, if they can be imported, ``IPython`` and
+    ``matplotlib``. It also shows MKL information, if available.
+
+    All modules provided in ``add_pckg`` are also shown.
+
+
+    Parameters
+    ----------
+    add_pckg : packages, optional
+        Package or list of packages to add to output information (must be
+        imported beforehand).
+
+    ncol : int, optional
+        Number of package-columns in html table; only has effect if
+        ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
+
+    **kwargs : dict
+        Passed through to scooby.
+
+
+    Examples
+    --------
+    >>> import pytest
+    >>> import dateutil
+    >>> from emg3d import Versions
+    >>> Versions()                            # Default values
+    >>> Versions(pytest)                      # Provide additional package
+    >>> Versions([pytest, dateutil], ncol=5)  # Set nr of columns
+
+    """
 
     def __init__(self, add_pckg=None, ncol=4, **kwargs):
         """Initiate a scooby.Report instance."""
@@ -1417,5 +1456,4 @@ class Versions(scooby.Report):
         # Optional packages.
         optional = ['IPython', 'matplotlib']
 
-        scooby.Report.__init__(self, additional=add_pckg, core=core,
-                               optional=optional, ncol=ncol, **kwargs)
+        super().__init__(add_pckg, core, optional, ncol=ncol, **kwargs)

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1429,11 +1429,14 @@ class Versions(scooby.Report):
         imported beforehand).
 
     ncol : int, optional
-        Number of package-columns in html table; only has effect if
-        ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
+        Number of package-columns in html table (no effect in text-version);
+        Defaults to 3.
 
-    **kwargs : dict
-        Passed through to scooby.
+    text_width : int, optional
+        The text width for non-HTML display modes
+
+    sort : bool, optional
+        Sort the packages when the report is shown
 
 
     Examples
@@ -1447,7 +1450,7 @@ class Versions(scooby.Report):
 
     """
 
-    def __init__(self, add_pckg=None, ncol=3, **kwargs):
+    def __init__(self, add_pckg=None, ncol=3, text_width=80, sort=False):
         """Initiate a scooby.Report instance."""
 
         # Mandatory packages.
@@ -1456,4 +1459,4 @@ class Versions(scooby.Report):
         # Optional packages.
         optional = ['IPython', 'matplotlib']
 
-        super().__init__(add_pckg, core, optional, ncol=ncol, **kwargs)
+        super().__init__(add_pckg, core, optional, ncol, text_width, sort)

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1447,7 +1447,7 @@ class Versions(scooby.Report):
 
     """
 
-    def __init__(self, add_pckg=None, ncol=4, **kwargs):
+    def __init__(self, add_pckg=None, ncol=3, **kwargs):
         """Initiate a scooby.Report instance."""
 
         # Mandatory packages.

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -24,41 +24,12 @@ Utility functions for the multigrid solver.
 
 
 import os
-import sys
-import time
-import numba
-import scipy
+import scooby
 import shelve
-import textwrap
-import platform
 import numpy as np
-import multiprocessing
 from timeit import default_timer
 from datetime import datetime, timedelta
 from scipy import optimize, interpolate, ndimage
-
-import emg3d  # emg3d for Versions
-
-# Optional modules
-try:
-    import IPython
-except ImportError:
-    IPython = False
-try:
-    import matplotlib
-except ImportError:
-    matplotlib = False
-try:
-    import mkl
-except ImportError:
-    mkl = False
-
-# Get mkl info, if available
-if mkl:
-    mklinfo = mkl.get_version_string()
-else:
-    mklinfo = False
-
 
 __all__ = ['Model', 'Field', 'get_domain', 'get_stretched_h', 'get_hx',
            'get_source_field', 'get_receiver', 'get_h_field', 'TensorMesh',
@@ -1435,183 +1406,16 @@ def data_read(fname, keys=None, path="data"):
 
 
 # OTHER
-class Versions:
-    r"""Print date, time, and version information.
+class Versions(scooby.Report):
 
-    Print date, time, and package version information in any environment
-    (Jupyter notebook, IPython console, Python console, QT console), either as
-    html-table (notebook) or as plain text (anywhere).
+    def __init__(self, add_pckg=None, ncol=4, **kwargs):
+        """Initiate a scooby.Report instance."""
 
-    Always shown are the OS, number of CPU(s), ``numpy``, ``scipy``,
-    ``emg3d``, ``numba``, ``sys.version``, and time/date.
+        # Mandatory packages.
+        core = ['numpy', 'scipy', 'numba', 'emg3d']
 
-    Additionally shown are, if they can be imported, ``IPython`` and
-    ``matplotlib``. It also shows MKL information, if available.
+        # Optional packages.
+        optional = ['IPython', 'matplotlib']
 
-    All modules provided in ``add_pckg`` are also shown. They have to be
-    imported before ``versions`` is called.
-
-    This script was heavily inspired by:
-
-        - ipynbtools.py from qutip https://github.com/qutip
-        - watermark.py from https://github.com/rasbt/watermark
-
-
-    Parameters
-    ----------
-    add_pckg : packages, optional
-        Package or list of packages to add to output information (must be
-        imported beforehand).
-
-    ncol : int, optional
-        Number of package-columns in html table; only has effect if
-        ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
-
-
-    Examples
-    --------
-    >>> import pytest
-    >>> import dateutil
-    >>> from emg3d import Versions
-    >>> Versions()                            # Default values
-    >>> Versions(pytest)                      # Provide additional package
-    >>> Versions([pytest, dateutil], ncol=5)  # Set nr of columns
-
-    """
-
-    def __init__(self, add_pckg=None, ncol=4):
-        """Initiate and add packages and number of columns to self."""
-        self.add_pckg = self._get_packages(add_pckg)
-        self.ncol = int(ncol)
-
-    def __repr__(self):
-        r"""Plain-text version information."""
-
-        # Width for text-version
-        n = 54
-        text = '\n' + n*'-' + '\n'
-
-        # Date and time info as title
-        text += time.strftime('  %a %b %d %H:%M:%S %Y %Z\n\n')
-
-        # OS and CPUs
-        text += '{:>15}'.format(platform.system())+' : OS\n'
-        text += '{:>15}'.format(multiprocessing.cpu_count())+' : CPU(s)\n'
-
-        # Loop over packages
-        for pckg in self.add_pckg:
-            text += '{:>15} : {}\n'.format(pckg.__version__, pckg.__name__)
-
-        # sys.version
-        text += '\n'
-        for txt in textwrap.wrap(sys.version, n-4):
-            text += '  '+txt+'\n'
-
-        # mkl version
-        if mklinfo:
-            text += '\n'
-            for txt in textwrap.wrap(mklinfo, n-4):
-                text += '  '+txt+'\n'
-
-        # Finish
-        text += n*'-'
-
-        return text
-
-    def _repr_html_(self):
-        """HTML-rendered version information."""
-
-        # Define html-styles
-        border = "border: 2px solid #fff;'"
-
-        def colspan(html, txt, ncol, nrow):
-            r"""Print txt in a row spanning whole table."""
-            html += "  <tr>\n"
-            html += "     <td style='text-align: center; "
-            if nrow == 0:
-                html += "font-weight: bold; font-size: 1.2em; "
-            elif nrow % 2 == 0:
-                html += "background-color: #ddd;"
-            html += border + " colspan='"
-            html += str(2*ncol)+"'>%s</td>\n" % txt
-            html += "  </tr>\n"
-            return html
-
-        def cols(html, version, name, ncol, i):
-            r"""Print package information in two cells."""
-
-            # Check if we have to start a new row
-            if i > 0 and i % ncol == 0:
-                html += "  </tr>\n"
-                html += "  <tr>\n"
-
-            html += "    <td style='text-align: right; background-color: #ccc;"
-            html += " " + border + ">%s</td>\n" % version
-
-            html += "    <td style='text-align: left; "
-            html += border + ">%s</td>\n" % name
-
-            return html, i+1
-
-        # Start html-table
-        html = "<table style='border: 3px solid #ddd;'>\n"
-
-        # Date and time info as title
-        html = colspan(html, time.strftime('%a %b %d %H:%M:%S %Y %Z'),
-                       self.ncol, 0)
-
-        # OS and CPUs
-        html += "  <tr>\n"
-        html, i = cols(html, platform.system(), 'OS', self.ncol, 0)
-        html, i = cols(html, multiprocessing.cpu_count(), 'CPU(s)',
-                       self.ncol, i)
-
-        # Loop over packages
-        for pckg in self.add_pckg:
-            html, i = cols(html, pckg.__version__, pckg.__name__, self.ncol, i)
-        # Fill up the row
-        while i % self.ncol != 0:
-            html += "    <td style= " + border + "></td>\n"
-            html += "    <td style= " + border + "></td>\n"
-            i += 1
-        # Finish row
-        html += "  </tr>\n"
-
-        # sys.version
-        html = colspan(html, sys.version, self.ncol, 1)
-
-        # mkl version
-        if mklinfo:
-            html = colspan(html, mklinfo, self.ncol, 2)
-
-        # Finish table
-        html += "</table>"
-
-        return html
-
-    @staticmethod
-    def _get_packages(add_pckg):
-        r"""Create list of packages."""
-
-        # Mandatory packages
-        pckgs = [np, scipy, numba, emg3d]
-
-        # Optional packages
-        for module in [IPython, matplotlib]:
-            if module:
-                pckgs += [module]
-
-        # Cast and add add_pckg
-        if add_pckg is not None:
-
-            # Cast add_pckg
-            if isinstance(add_pckg, tuple):
-                add_pckg = list(add_pckg)
-
-            if not isinstance(add_pckg, list):
-                add_pckg = [add_pckg, ]
-
-            # Add add_pckg
-            pckgs += add_pckg
-
-        return pckgs
+        scooby.Report.__init__(self, additional=add_pckg, core=core,
+                               optional=optional, ncol=ncol, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sphinx_rtd_theme
 numpy >= 1.15.0
 scipy >= 1.1.0
 numba >= 0.40.0
-scooby > 0.2
+scooby >= 0.3.0
 
 # sphinx fixed below 2.0
 # https://github.com/numpy/numpydoc/issues/215

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ sphinx_rtd_theme
 numpy >= 1.15.0
 scipy >= 1.1.0
 numba >= 0.40.0
+scooby > 0.2
 
 # sphinx fixed below 2.0
 # https://github.com/numpy/numpydoc/issues/215

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,15 +17,12 @@ where:
 
 "
 
-# TODO: ONE run with NUMBA_DISABLE_JIT="1"; the rest without; for coverage.
-
 # Set default values
-CHAN=defaults
 PYTHON3VERSION="7"
 PRINT="/dev/null"
-PCKGS="numpy scipy pytest pytest-cov matplotlib numba scooby"
+PCKGS="numpy scipy pytest pytest-cov numba"
 PROPS="--flake8"
-INST="pytest-flake8 discretize"
+INST="pytest-flake8 scooby"
 WARN=""
 DISABLENUMBA=false
 
@@ -77,7 +74,7 @@ for i in ${PYTHON3VERSION[@]}; do
   printf '%*s\n' "${LENGTH}" '' | tr ' ' -
   printf "\e[0m\n"
 
-  # Create venv, with channel CHAN
+  # Create venv
   if [ ! -d "$HOME/anaconda3/envs/$NAME" ]; then
     conda create -y -n $NAME python=3.${i} $PCKGS &> $PRINT
   fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -23,7 +23,7 @@ where:
 CHAN=defaults
 PYTHON3VERSION="7"
 PRINT="/dev/null"
-PCKGS="numpy scipy pytest pytest-cov matplotlib numba"
+PCKGS="numpy scipy pytest pytest-cov matplotlib numba scooby"
 PROPS="--flake8"
 INST="pytest-flake8 discretize"
 WARN=""

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
         'numpy>=1.15.0',
         'scipy>=1.1.0',
         'numba>=0.40.0',
+        'scooby>0.2.0'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         'numpy>=1.15.0',
         'scipy>=1.1.0',
         'numba>=0.40.0',
-        'scooby>0.2.0'
+        'scooby>=0.3.0'
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import re
 import os
+import scooby
 import pytest
 import numpy as np
 from scipy import constants
@@ -536,40 +537,10 @@ def test_data_write_read(tmpdir, capsys):
 # OTHER
 def test_versions(capsys):
 
-    # Check the default
-    print(utils.Versions())
-    out1, _ = capsys.readouterr()
+    out1 = utils.Versions()
+    out2 = scooby.Report(
+            core=['numpy', 'scipy', 'numba', 'emg3d'],
+            optional=['IPython', 'matplotlib'],
+            ncol=4)
 
-    # Check one of the standard packages
-    assert 'numpy' in out1
-
-    # Check with an additional package
-    print(utils.Versions(add_pckg=re))
-    out2, _ = capsys.readouterr()
-
-    # Check the provided package, with number
-    assert re.__version__ + ' : re' in out2
-
-    # Check the 'text'-version, providing a package as tuple
-    v1 = utils.Versions(add_pckg=(re, ))
-    print(v1.__repr__())
-    out3, _ = capsys.readouterr()
-
-    # They have to be the same, except time (run at slightly different times)
-    assert out2[75:] == out3[75:]
-
-    # Check 'HTML'/'html'-version, providing a package as a list
-    v2 = utils.Versions(add_pckg=[re])
-    print(v2._repr_html_())
-    out4, _ = capsys.readouterr()
-
-    assert 'numpy' in out4
-    assert 'td style=' in out4
-
-    # Check row of provided package, with number
-    teststr = "<td style='text-align: right; background-color: #ccc; "
-    teststr += "border: 2px solid #fff;'>"
-    teststr += re.__version__
-    teststr += "</td>\n    <td style='"
-    teststr += "text-align: left; border: 2px solid #fff;'>re</td>"
-    assert teststr in out4
+    assert out1.__repr__()[200:] == out2.__repr__()[200:]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -537,10 +537,13 @@ def test_data_write_read(tmpdir, capsys):
 # OTHER
 def test_versions(capsys):
 
+    # Reporting is now done by the external package scooby.
+    # We just ensure the shown packages do not change (core and optional).
     out1 = utils.Versions()
     out2 = scooby.Report(
             core=['numpy', 'scipy', 'numba', 'emg3d'],
             optional=['IPython', 'matplotlib'],
             ncol=4)
 
-    assert out1.__repr__()[200:] == out2.__repr__()[200:]
+    # Ensure they're the same; exclude time to avoid errors.
+    assert out1.__repr__()[115:] == out2.__repr__()[115:]


### PR DESCRIPTION
Now that `scooby` exists we should, for simplicity, simply use it.