### PR TITLE
Move from `Versions` to `Report`

### DIFF
--- a/emg3d/__init__.py
+++ b/emg3d/__init__.py
@@ -25,8 +25,8 @@ sped-up through jitted ``numba``-functions.
 
 from . import utils
 from . import solver
-from .utils import Versions
+from .utils import Report
 
-__all__ = ['solver', 'utils', 'Versions']
+__all__ = ['solver', 'utils', 'Report']
 
 __version__ = '0.6.3dev0'

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -33,7 +33,7 @@ from scipy import optimize, interpolate, ndimage
 
 __all__ = ['Model', 'Field', 'get_domain', 'get_stretched_h', 'get_hx',
            'get_source_field', 'get_receiver', 'get_h_field', 'TensorMesh',
-           'Time', 'data_write', 'data_read', 'Versions']
+           'Time', 'data_write', 'data_read', 'Report']
 
 
 # CONSTANTS
@@ -1406,7 +1406,7 @@ def data_read(fname, keys=None, path="data"):
 
 
 # OTHER
-class Versions(scooby.Report):
+class Report(scooby.Report):
     r"""Print date, time, and version information.
 
     Use scooby to print date, time, and package version information in any
@@ -1443,10 +1443,10 @@ class Versions(scooby.Report):
     --------
     >>> import pytest
     >>> import dateutil
-    >>> from emg3d import Versions
-    >>> Versions()                            # Default values
-    >>> Versions(pytest)                      # Provide additional package
-    >>> Versions([pytest, dateutil], ncol=5)  # Set nr of columns
+    >>> from emg3d import Report
+    >>> Report()                            # Default values
+    >>> Report(pytest)                      # Provide additional package
+    >>> Report([pytest, dateutil], ncol=5)  # Set nr of columns
 
     """
 

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1459,4 +1459,5 @@ class Report(scooby.Report):
         # Optional packages.
         optional = ['IPython', 'matplotlib']
 
-        super().__init__(add_pckg, core, optional, ncol, text_width, sort)
+        super().__init__(additional=add_pckg, core=core, optional=optional,
+                         ncol=ncol, text_width=text_width, sort=sort)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -535,11 +535,11 @@ def test_data_write_read(tmpdir, capsys):
 
 
 # OTHER
-def test_versions(capsys):
+def test_report(capsys):
 
     # Reporting is now done by the external package scooby.
     # We just ensure the shown packages do not change (core and optional).
-    out1 = utils.Versions()
+    out1 = utils.Report()
     out2 = scooby.Report(
             core=['numpy', 'scipy', 'numba', 'emg3d'],
             optional=['IPython', 'matplotlib'],


### PR DESCRIPTION
`scooby` uses default. We should change to `Report` to, it should become the 'standard' term for reporting.