### PR TITLE
Possibility to retrieve runtime info

### DIFF
--- a/emg3d/solver.py
+++ b/emg3d/solver.py
@@ -214,12 +214,21 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
           level in any direction by its value.
           Default is -1.
 
+        - ``return_info`` : bool
+
+          If True, a dictionary is returned with runtime info (final norm and
+          number of iterations of MG and the sslsolver).
+
 
     Returns
     -------
     efield : Field instance
         Resulting electric field. Is not returned but replaced in-place if an
         initial efield was provided.
+
+    info_dict : dict
+        Dictionary with runtime info (final norm and number of iterations of MG
+        and the sslsolver); only if ``return_info=True``.
 
 
     Examples
@@ -294,6 +303,9 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
 
     """
 
+    # Get return_info from kwargs.
+    return_info = kwargs.pop('return_info', False)
+
     # Solver settings; get from kwargs or set to default values.
     var = MGParameters(
             cycle=cycle, sslsolver=sslsolver, semicoarsening=semicoarsening,
@@ -362,9 +374,16 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
     # used in CSEM, we return the conjugate.
     np.conjugate(efield, efield)
 
-    # If efield was not provided, return it.
-    if do_return:
+    # Assemble the info_dict if return_info
+    info_dict = {'norm': var.l2, 'it_mg': var.it, 'it_ssl': var._ssl_it}
+
+    # Return depending on input arguments; or nothing.
+    if do_return and return_info:  # efield and info.
+        return efield, info_dict
+    elif do_return:                # efield.
         return efield
+    elif return_info:              # info.
+        return info_dict
 
 
 # SOLVERS

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -84,9 +84,12 @@ def test_solver_homogeneous(capsys):
     assert ' emg3d END   :: ' in out
 
     # Max it
-    _ = solver.solver(grid, model, sfield, verb=2, maxit=1)
+    maxit = 2
+    _, info = solver.solver(
+            grid, model, sfield, verb=2, maxit=maxit, return_info=True)
     out, _ = capsys.readouterr()
     assert ' MAX. ITERATION REACHED' in out
+    assert maxit == info['it_mg']
 
     # BiCGSTAB with lower verbosity, print checking.
     _ = solver.solver(grid, model, sfield, verb=2, maxit=1, sslsolver=True)
@@ -109,6 +112,12 @@ def test_solver_homogeneous(capsys):
     assert "NOTHING DONE (provided efield already good enough)" in out
     # Ensure the field did not change.
     assert_allclose(efield, efield_copy)
+
+    # Provide initial field and return info.
+    info = solver.solver(
+            grid, model, sfield, efield_copy, return_info=True)
+    assert info['it_mg'] == 0
+    assert info['it_ssl'] == 0
 
     # Check stagnation by providing zero source field.
     _ = solver.solver(grid, model, sfield*0)


### PR DESCRIPTION
New bool-`kwarg`: `return_info`. If `True`, `emg3d` will return a dict with final norm and number of MG and sslsolver iterations.

Closes #10.