### PR TITLE
Workaround for #31

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 #########
 
 
+*latest*
+--------
+
+- Bugfix and workaround for the case where a ``sslsolver`` is used together
+  with a provided initial ``efield``.
+
+
 *v0.7.1* : JOSS article
 -----------------------
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -128,6 +128,17 @@ def test_solver_homogeneous(capsys):
     assert info['exit'] == 0
     assert info['exit_message'] == 'CONVERGED'
 
+    # Provide initial field, ensure one initial multigrid is carried out
+    # without linerelaxation nor semicoarsening.
+    _, _ = capsys.readouterr()  # empty
+    efield = utils.Field(grid)
+    outarray = solver.solver(
+            grid, model, sfield, efield, sslsolver=True, semicoarsening=True,
+            linerelaxation=True, maxit=2, verb=3)
+    out, _ = capsys.readouterr()
+    assert "after                       1 F-cycles    0 0" in out
+    assert "after                       2 F-cycles    4 1" in out
+
     # Check stagnation by providing an almost zero source field.
     _ = solver.solver(grid, model, sfield*0+1e-20)
     out, _ = capsys.readouterr()


### PR DESCRIPTION
If an initial field is provided and a sslsolver is used, then it first carries out one multigrid cycle without semicoarsening nor line relaxation. The sslsolver is at times unstable with an initial guess, carrying out one MG cycle helps to stabilize it.