### PR TITLE
Rename solver to solve

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 #########
 
 
+*latest*
+--------
+
+- Rename ``solver.solver`` to ``solver.solve``; load ``solve`` also into the
+  main namespace as ``emg3d.solve``.
+
+
 *v0.9.2* : Complex sources
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 
 - Rename ``solver.solver`` to ``solver.solve``; load ``solve`` also into the
   main namespace as ``emg3d.solve``.
+- Adjustment to ``utils.get_hx_h0`` (this might change your boundaries): The
+  calculation domain is now calculated so that the distance for the signal
+  travelling from the source to the boundary and back to the most remote
+  receiver is at least two wavelengths away. If this is within the provided
+  domain, then now extra buffer is added around the domain.
 
 
 *v0.9.2* : Complex sources

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -5,7 +5,7 @@ Code
 
 .. automodule:: emg3d.solver
     :members:
-    :exclude-members: solver
+    :exclude-members: solve, solver
 
 .. automodule:: emg3d.njitted
     :members:

--- a/docs/solver.rst
+++ b/docs/solver.rst
@@ -3,4 +3,4 @@ Main solver routine
 
 .. _solver:
 
-.. autofunction:: emg3d.solver.solver
+.. autofunction:: emg3d.solver.solve

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -8,10 +8,10 @@ solver `emg3d`. More specific theory is covered in the docstrings of many
 functions, have a look at the :doc:`code`-section or follow the links to the
 corresponding functions here within the theory. If you just want to use the
 solver, but do not care much about the internal functionality, then the
-function :func:`emg3d.solver.solver` is the only function you will ever need.
-It is the main entry point, and it takes care whether multigrid is used as a
-solver or as a preconditioner (or not at all), while the actual multigrid
-solver is :func:`emg3d.solver.multigrid`.
+function :func:`emg3d.solve` is the only function you will ever need. It is the
+main entry point, and it takes care whether multigrid is used as a solver or as
+a preconditioner (or not at all), while the actual multigrid solver is
+:func:`emg3d.solver.multigrid`.
 
 .. note::
 
@@ -150,9 +150,9 @@ using a real value for :math:`s` in Equation :eq:`fdomaindiff`, instead of the
 complex value :math:`-\mathrm{i}\omega``. This simplifies the problem from
 complex numbers to real numbers, which accelerates the calculation. It also
 improves the convergence rate, as the solution is a smoother function. The
-solver :func:`emg3d.solver.solver` is agnostic to the data type of the provided
-source field, and can solve for real and complex problems, hence frequency and
-Laplace domain. See the documentation of the functions
+solver :func:`emg3d.solve` is agnostic to the data type of the provided source
+field, and can solve for real and complex problems, hence frequency and Laplace
+domain. See the documentation of the functions
 :func:`emg3d.utils.get_source_field` and :func:`emg3d.utils.Model` to see how
 you can use `emg3d` for Laplace-domain calculations.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,9 +56,8 @@ contain references to ``blas``, ``lapack``, ``openblas``, or similar.
 
 The structure of emg3d is:
 
-- **solver.py**: The main multigrid solver routine, where
-  ``emg3d.solver.solver`` is the principal user-facing routine
-  (see :doc:`solver`).
+- **solver.py**: The main multigrid solver routine, where ``emg3d.solve`` is
+  the principal user-facing routine (see :doc:`solver`).
 - **utils.py**: Utilities such as helper functions to create meshes, models,
   and source fields.
 - **njitted.py**: The heavy calculations, all ``numba``-jitted functions.
@@ -124,7 +123,7 @@ Now we can calculate the electric field with ``emg3d``:
 
 .. code-block:: python
 
-    >>> efield = emg3d.solver.solver(grid, model, sfield, verb=3)
+    >>> efield = emg3d.solve(grid, model, sfield, verb=3)
 
     :: emg3d START :: 15:24:40 :: v0.9.1
 
@@ -191,11 +190,11 @@ use emg3d together with the mentioned projects and more!
 Tipps and Tricks
 ----------------
 
-The function :func:`emg3d.solver.solver` is the main entry point, and it takes
-care whether multigrid is used as a solver or as a preconditioner (or not at
-all), while the actual multigrid solver is :func:`emg3d.solver.multigrid`.
-Most input parameters for :func:`emg3d.solver.solver` are sufficiently
-described in its docstring. Here a few additional information.
+The function :func:`emg3d.solve` is the main entry point, and it takes care
+whether multigrid is used as a solver or as a preconditioner (or not at all),
+while the actual multigrid solver is :func:`emg3d.solver.multigrid`. Most input
+parameters for :func:`emg3d.solve` are sufficiently described in its docstring.
+Here a few additional information.
 
 - You can input any three-dimensional grid into `emg3d`. However, the
   implemented multigrid technique works with the existing nodes, meaning there

--- a/emg3d/__init__.py
+++ b/emg3d/__init__.py
@@ -25,9 +25,10 @@ sped-up through jitted ``numba``-functions.
 
 from emg3d import utils
 from emg3d import solver
+from emg3d.solver import solve
 from emg3d.utils import Report
 
-__all__ = ['solver', 'utils', 'Report']
+__all__ = ['solve', 'solver', 'utils', 'Report']
 
 # Version is sorted out in utils, so we can easier use it within the package
 # itself.

--- a/emg3d/solver.py
+++ b/emg3d/solver.py
@@ -32,13 +32,13 @@ from dataclasses import dataclass
 from emg3d import utils
 from emg3d import njitted
 
-__all__ = ['solver', 'multigrid', 'smoothing', 'restriction', 'prolongation',
+__all__ = ['solve', 'multigrid', 'smoothing', 'restriction', 'prolongation',
            'residual', 'krylov', 'MGParameters', 'RegularGridProlongator']
 
 
 # MAIN USER-FACING FUNCTION
-def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
-           semicoarsening=False, linerelaxation=False, verb=2, **kwargs):
+def solve(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
+          semicoarsening=False, linerelaxation=False, verb=2, **kwargs):
     r"""Solver for 3D CSEM data with tri-axial electrical anisotropy.
 
     The principal solver of `emg3d` is using the multigrid method as presented
@@ -264,7 +264,7 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
     >>> sfield = emg3d.utils.get_source_field(
     >>>         grid, src=[4, 4, 4, 0, 0], freq=10)
     >>> # Calculate the electric signal.
-    >>> efield = emg3d.solver.solver(grid, model, sfield, verb=3)
+    >>> efield = emg3d.solve(grid, model, sfield, verb=3)
     >>> # Get the corresponding magnetic signal.
     >>> hfield = emg3d.utils.get_h_field(grid, model, efield)
     .
@@ -418,6 +418,19 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
         return efield
     elif var.return_info:                  # info.
         return info_dict
+
+
+def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
+           semicoarsening=False, linerelaxation=False, verb=2, **kwargs):
+    """Alias to solve(), for backwards compatibility."""
+
+    # Issue warning for backwards compatibility.
+    print("\n    ``emg3d.solver.solver()`` is renamed to ``emg3d.solve()``."
+          "\n    Use the new ``emg3d.solve()``, as ``solver()`` will be "
+          "removed in the future.")
+
+    return solve(grid, model, sfield, efield, cycle, sslsolver, semicoarsening,
+                 linerelaxation, verb, **kwargs)
 
 
 # SOLVERS

--- a/emg3d/solver.py
+++ b/emg3d/solver.py
@@ -425,9 +425,9 @@ def solver(grid, model, sfield, efield=None, cycle='F', sslsolver=False,
     """Alias to solve(), for backwards compatibility."""
 
     # Issue warning for backwards compatibility.
-    print("\n    ``emg3d.solver.solver()`` is renamed to ``emg3d.solve()``."
-          "\n    Use the new ``emg3d.solve()``, as ``solver()`` will be "
-          "removed in the future.")
+    print("\n* WARNING :: ``emg3d.solver.solver()`` is renamed to "
+          "``emg3d.solve()``.\n             Use the new ``emg3d.solve()``, as "
+          "``solver()`` will be\n             removed in the future.")
 
     return solve(grid, model, sfield, efield, cycle, sslsolver, semicoarsening,
                  linerelaxation, verb, **kwargs)

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -886,8 +886,9 @@ class Model:
 
         # Issue warning for backwards compatibility.
         if freq is not None:
-            print("\n    ``Model`` does not take frequency ``freq`` any "
-                  "longer;\n    providing it will break in the future.")
+            print("\n* WARNING :: ``Model`` is independent of frequency and "
+                  "does not take\n             ``freq`` any longer; providing "
+                  "it will break in the future.")
 
         # Store required info from grid.
         self.nC = grid.nC

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1608,13 +1608,20 @@ def get_hx_h0(freq, res, domain, fixed=0., possible_nx=None, min_width=None,
         else:
             dmin = np.clip(dmin, *min_width)
 
-    # Survey domain.
+    # Survey domain; contains all sources and receivers.
     domain = np.array(domain, dtype=float)
 
-    # Calculation domain.
-    calc_domain = skind[1:]*np.array([6., 6.])  # 6 x sd => buffer zone.
-    calc_domain[0] = domain[0] - calc_domain[0]
-    calc_domain[1] = domain[1] + calc_domain[1]
+    # Calculation domain; big enough to avoid boundary effects.
+    # To avoid boundary effects we want the signal to travel two wavelengths
+    # from the source to the boundary and back to the receiver.
+    # => 2*pi*sd ~ 6.3*sd = one wavelength => signal is ~ 0.2 %.
+    # Two wavelengths we can savely assume it is zero.
+    dist_in_domain = abs(domain - fixed[0])  # Source to edges of domain.
+    dist_buff = skind[1:]*4*np.pi            # 2 wavelengths
+    dist_buff = np.max([np.zeros(2), (dist_buff - dist_in_domain)/2], axis=0)
+    calc_domain = np.array([domain[0]-dist_buff[0], domain[1]+dist_buff[1]])
+    # print(f"New :: {calc_domain[0]}, {calc_domain[1]}")
+    # print(f"Old :: {domain[0] - skind[1]*6}, {domain[1] + skind[2]*6}")
 
     # Initiate flag if terminated.
     finished = False

--- a/tests/create_data/regression.py
+++ b/tests/create_data/regression.py
@@ -36,16 +36,16 @@ input_source = {
 sfield = utils.get_source_field(**input_source)
 
 # F-cycle
-fefield = solver.solver(grid, model, sfield)
+fefield = solver.solve(grid, model, sfield)
 
 # W-cycle
-wefield = solver.solver(grid, model, sfield, cycle='W')
+wefield = solver.solve(grid, model, sfield, cycle='W')
 
 # V-cycle
-vefield = solver.solver(grid, model, sfield, cycle='V')
+vefield = solver.solve(grid, model, sfield, cycle='V')
 
 # BiCGSTAB; F-cycle
-bicefield = solver.solver(grid, model, sfield, sslsolver=True)
+bicefield = solver.solve(grid, model, sfield, sslsolver=True)
 
 out = {
     'input_grid': input_grid,
@@ -96,7 +96,7 @@ nu_coarse = 1
 nu_post = 2
 clevel = 10  # Way to high
 
-efield = solver.solver(
+efield = solver.solve(
         grid, model, sfield,
         semicoarsening=semicoarsening, linerelaxation=linerelaxation,
         verb=verb, tol=tol, maxit=maxit, nu_init=nu_init, nu_pre=nu_pre,
@@ -178,10 +178,10 @@ input_source_l = {
 sfield_l = utils.get_source_field(**input_source_l)
 
 # F-cycle
-fefield_l = solver.solver(grid_l, model_l, sfield_l)
+fefield_l = solver.solve(grid_l, model_l, sfield_l)
 
 # BiCGSTAB; F-cycle
-bicefield_l = solver.solver(grid_l, model_l, sfield_l, sslsolver=True)
+bicefield_l = solver.solve(grid_l, model_l, sfield_l, sslsolver=True)
 
 out_l = {
     'input_grid': input_grid_l,

--- a/tests/test_njitted.py
+++ b/tests/test_njitted.py
@@ -33,7 +33,7 @@ def test_amat_x():
     vmodel = utils.VolumeModel(grid, model, sfield)
 
     # Run two iterations to get a e-field
-    efield = solver.solver(grid, model, sfield, maxit=2, verb=1)
+    efield = solver.solve(grid, model, sfield, maxit=2, verb=1)
 
     # amat_x
     rr1 = utils.Field(grid)
@@ -114,7 +114,7 @@ def test_gauss_seidel():
         vmodel = utils.VolumeModel(grid, model, sfield)
 
         # Run two iterations to get some e-field.
-        efield = solver.solver(grid, model, sfield, maxit=2, verb=1)
+        efield = solver.solve(grid, model, sfield, maxit=2, verb=1)
 
         inp = (sfield.fx, sfield.fy, sfield.fz, vmodel.eta_x, vmodel.eta_y,
                vmodel.eta_z, vmodel.zeta, grid.hx, grid.hy, grid.hz, nu)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -207,7 +207,7 @@ def test_solver_backwards(capsys):
     out, _ = capsys.readouterr()
     _ = solver.solver(grid, model, sfield, verb=0)
     out, _ = capsys.readouterr()
-    assert '``emg3d.solver.solver()`` is renamed to ``emg3d.solve()``.' in out
+    assert "* WARNING :: ``emg3d.solver.solver()`` is renamed to " in out
 
 
 def test_one_liner(capsys):

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -34,7 +34,7 @@ def test_solver_homogeneous(capsys):
     sfield = utils.get_source_field(**dat['input_source'])
 
     # F-cycle
-    efield = solver.solver(grid, model, sfield, verb=4)
+    efield = solver.solve(grid, model, sfield, verb=4)
     out, _ = capsys.readouterr()
 
     assert ' emg3d START ::' in out
@@ -52,20 +52,20 @@ def test_solver_homogeneous(capsys):
     assert_allclose(dat['Fresult'], efield)
 
     # W-cycle
-    wfield = solver.solver(grid, model, sfield, cycle='W', verb=1)
+    wfield = solver.solve(grid, model, sfield, cycle='W', verb=1)
 
     # Check all fields (ex, ey, and ez)
     assert_allclose(dat['Wresult'], wfield)
 
     # V-cycle
-    vfield = solver.solver(grid, model, sfield, cycle='V', verb=1)
+    vfield = solver.solve(grid, model, sfield, cycle='V', verb=1)
     _, _ = capsys.readouterr()  # clear output
 
     # Check all fields (ex, ey, and ez)
     assert_allclose(dat['Vresult'], vfield)
 
     # BiCGSTAB with some print checking.
-    efield = solver.solver(grid, model, sfield, verb=3, sslsolver=True)
+    efield = solver.solve(grid, model, sfield, verb=3, sslsolver=True)
     out, _ = capsys.readouterr()
     assert ' emg3d START ::' in out
     assert ' [hh:mm:ss] ' in out
@@ -79,7 +79,7 @@ def test_solver_homogeneous(capsys):
     assert_allclose(dat['bicresult'], efield)
 
     # Same as previous, without BiCGSTAB, but some print checking.
-    efield = solver.solver(grid, model, sfield, verb=3)
+    efield = solver.solve(grid, model, sfield, verb=3)
     out, _ = capsys.readouterr()
     assert ' emg3d START ::' in out
     assert ' [hh:mm:ss] ' in out
@@ -90,7 +90,7 @@ def test_solver_homogeneous(capsys):
 
     # Max it
     maxit = 2
-    _, info = solver.solver(
+    _, info = solver.solve(
             grid, model, sfield, verb=2, maxit=maxit, return_info=True)
     out, _ = capsys.readouterr()
     assert ' MAX. ITERATION REACHED' in out
@@ -99,18 +99,18 @@ def test_solver_homogeneous(capsys):
     assert 'MAX. ITERATION REACHED' in info['exit_message']
 
     # BiCGSTAB with lower verbosity, print checking.
-    _ = solver.solver(grid, model, sfield, verb=2, maxit=1, sslsolver=True)
+    _ = solver.solve(grid, model, sfield, verb=2, maxit=1, sslsolver=True)
     out, _ = capsys.readouterr()
     assert ' MAX. ITERATION REACHED' in out
 
     # Just check if it runs without failing for other solvers.
-    _ = solver.solver(grid, model, sfield, verb=3, maxit=1,
-                      sslsolver='gcrotmk')
+    _ = solver.solve(grid, model, sfield, verb=3, maxit=1,
+                     sslsolver='gcrotmk')
 
     # Provide initial field.
     _, _ = capsys.readouterr()  # empty
     efield_copy = efield.copy()
-    outarray = solver.solver(grid, model, sfield, efield_copy)
+    outarray = solver.solve(grid, model, sfield, efield_copy)
     out, _ = capsys.readouterr()
 
     # Ensure there is no output.
@@ -120,7 +120,7 @@ def test_solver_homogeneous(capsys):
     assert_allclose(efield, efield_copy)
 
     # Provide initial field and return info.
-    info = solver.solver(
+    info = solver.solve(
             grid, model, sfield, efield_copy, return_info=True)
     assert info['it_mg'] == 0
     assert info['it_ssl'] == 0
@@ -131,7 +131,7 @@ def test_solver_homogeneous(capsys):
     # without linerelaxation nor semicoarsening.
     _, _ = capsys.readouterr()  # empty
     efield = utils.Field(grid)
-    outarray = solver.solver(
+    outarray = solver.solve(
             grid, model, sfield, efield, sslsolver=True, semicoarsening=True,
             linerelaxation=True, maxit=2, verb=3)
     out, _ = capsys.readouterr()
@@ -142,12 +142,12 @@ def test_solver_homogeneous(capsys):
     wrong_sfield = utils.Field(grid)
     wrong_sfield.field = sfield.field
     with pytest.raises(ValueError):
-        solver.solver(grid, model, wrong_sfield, efield=efield, verb=2)
+        solver.solve(grid, model, wrong_sfield, efield=efield, verb=2)
     out, _ = capsys.readouterr()
     assert "ERROR   :: Source field is missing frequency information" in out
 
     # Check stagnation by providing an almost zero source field.
-    _ = solver.solver(grid, model, sfield*0+1e-20, maxit=100)
+    _ = solver.solve(grid, model, sfield*0+1e-20, maxit=100)
     out, _ = capsys.readouterr()
     assert "STAGNATED" in out
 
@@ -161,24 +161,24 @@ def test_solver_heterogeneous(capsys):
     inp = dat['inp']
     inp['verb'] = 4
 
-    efield = solver.solver(grid, model, sfield, **inp)
+    efield = solver.solve(grid, model, sfield, **inp)
 
     assert_allclose(dat['result'], efield.field)
 
     # Check with provided e-field; 2x2 iter should yield the same as 4 iter.
-    efield2 = solver.solver(grid, model, sfield, maxit=4, verb=1)
-    efield3 = solver.solver(grid, model, sfield, maxit=2, verb=1)
-    solver.solver(grid, model, sfield, efield3, maxit=2, verb=1)
+    efield2 = solver.solve(grid, model, sfield, maxit=4, verb=1)
+    efield3 = solver.solve(grid, model, sfield, maxit=2, verb=1)
+    solver.solve(grid, model, sfield, efield3, maxit=2, verb=1)
 
     assert_allclose(efield2, efield3)
 
     out, _ = capsys.readouterr()  # Clean up
 
     # One test without post-smoothing to check if it runs.
-    efield4 = solver.solver(
+    efield4 = solver.solve(
             grid, model, sfield, sslsolver=True, semicoarsening=True,
             linerelaxation=True, maxit=20, nu_pre=0, nu_post=4, verb=3)
-    efield5 = solver.solver(
+    efield5 = solver.solve(
             grid, model, sfield, sslsolver=True, semicoarsening=True,
             linerelaxation=True, maxit=20, nu_pre=4, nu_post=0, verb=3)
     # They don't converge, and hence don't agree. Just a lazy test.
@@ -192,10 +192,22 @@ def test_solver_heterogeneous(capsys):
             x0=np.array([-0.5, -1, -1]))
     sfield = utils.get_source_field(mesh, [0, 0, 0, 0, 0], 1)
     model = utils.Model(mesh)
-    _ = solver.solver(mesh, model, sfield, verb=3, nu_pre=0)
+    _ = solver.solve(mesh, model, sfield, verb=3, nu_pre=0)
     out, _ = capsys.readouterr()
     assert "(Cycle-QC restricted to first 70 steps of 72 steps.)" in out
     assert "DIVERGED" in out
+
+
+def test_solver_backwards(capsys):
+    grid = utils.TensorMesh(
+            [np.ones(8), np.ones(8), np.ones(8)], x0=np.array([0, 0, 0]))
+    model = utils.Model(grid, res_x=1.5, res_y=1.8, res_z=3.3)
+    sfield = utils.get_source_field(grid, src=[4, 4, 4, 0, 0], freq=10.0)
+
+    out, _ = capsys.readouterr()
+    _ = solver.solver(grid, model, sfield, verb=0)
+    out, _ = capsys.readouterr()
+    assert '``emg3d.solver.solver()`` is renamed to ``emg3d.solve()``.' in out
 
 
 def test_one_liner(capsys):
@@ -205,13 +217,13 @@ def test_one_liner(capsys):
     sfield = utils.get_source_field(grid, src=[4, 4, 4, 0, 0], freq=10.0)
 
     out, _ = capsys.readouterr()
-    _ = solver.solver(grid, model, sfield, verb=-1)
+    _ = solver.solve(grid, model, sfield, verb=-1)
     out, _ = capsys.readouterr()
     assert '6; 0:00:' in out
     assert '; CONVERGED' in out
 
     out, _ = capsys.readouterr()
-    _ = solver.solver(grid, model, sfield, sslsolver=True, verb=-1)
+    _ = solver.solve(grid, model, sfield, sslsolver=True, verb=-1)
     out, _ = capsys.readouterr()
     assert '3(5); 0:00:' in out
     assert '; CONVERGED' in out
@@ -227,13 +239,13 @@ def test_solver_homogeneous_laplace():
     sfield = utils.get_source_field(**dat['input_source'])
 
     # F-cycle
-    efield = solver.solver(grid, model, sfield, verb=1)
+    efield = solver.solve(grid, model, sfield, verb=1)
 
     # Check all fields (ex, ey, and ez)
     assert_allclose(dat['Fresult'], efield)
 
     # BiCGSTAB with some print checking.
-    efield = solver.solver(grid, model, sfield, verb=1, sslsolver=True)
+    efield = solver.solve(grid, model, sfield, verb=1, sslsolver=True)
 
     # Check all fields (ex, ey, and ez)
     assert_allclose(dat['bicresult'], efield)
@@ -242,7 +254,7 @@ def test_solver_homogeneous_laplace():
     efield = utils.Field(grid, dtype=complex)
 
     with pytest.raises(ValueError):
-        efield = solver.solver(grid, model, sfield, efield=efield, verb=1)
+        efield = solver.solve(grid, model, sfield, efield=efield, verb=1)
 
 
 def multigrid():
@@ -287,7 +299,7 @@ def test_smoothing():
         vmodel = utils.VolumeModel(grid, model, sfield)
 
         # Run two iterations to get an e-field
-        field = solver.solver(grid, model, sfield, maxit=2, verb=1)
+        field = solver.solve(grid, model, sfield, maxit=2, verb=1)
 
         # Collect Gauss-Seidel input (same for all routines)
         inp = (sfield.fx, sfield.fy, sfield.fz, vmodel.eta_x, vmodel.eta_y,
@@ -396,7 +408,7 @@ def test_residual():
     vmodel = utils.VolumeModel(grid, model, sfield)
 
     # Run two iterations to get an e-field
-    efield = solver.solver(grid, model, sfield, maxit=2, verb=1)
+    efield = solver.solve(grid, model, sfield, maxit=2, verb=1)
 
     # Use directly amat_x
     rfield = sfield.copy()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,7 +54,7 @@ def test_get_hx_h0(capsys):
     info = (
         "   Skin depth          [m] : 2251\n"
         "   Survey domain       [m] : -2000 - 2000\n"
-        "   Calculation domain  [m] : -15505 - 15505\n"
+        "   Calculation domain  [m] : -14692 - 15592\n"
         "   Final extent        [m] : -15698 - 15998\n"
         f"   Min/max cell width  [m] : {out1[2]['dmin']:.0f} / 750 / 3382\n"
         "   Alpha survey/calc       : "
@@ -146,7 +146,7 @@ def test_get_hx_h0(capsys):
     assert out7[1] < -10000
     assert out7[1]+np.sum(out7[0]) > 10000
 
-    out8 = utils.get_hx_h0(1, [0.3, 1, 100], [-1000, 1000], alpha=[1, 1, 1])
+    out8 = utils.get_hx_h0(1, [0.3, 1, 90], [-1000, 1000], alpha=[1, 1, 1])
     assert out8[1] > -5000                  # Left buffer much smaller than
     assert out8[1]+np.sum(out8[0]) > 30000  # right buffer.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -433,7 +433,7 @@ def test_Model(capsys):
     model1.epsilon_r = None
     vmodel1 = utils.VolumeModel(grid, model1, sfield)
     out, _ = capsys.readouterr()
-    assert '``Model`` does not take frequency' in out
+    assert '* WARNING :: ``Model`` is independent of frequency' in out
     assert_allclose(model1.res_x, model1.res_y)
     assert_allclose(model1.nC, grid.nC)
     assert_allclose(model1.vnC, grid.vnC)


### PR DESCRIPTION
Avoid clash between submodule `emg3d.solver` and routine `emg3d.solver.solver()` by renaming `emg3d.solver.solver()` to `emg3d.solver.solve()`. Now `solve()` is also loaded into the top-namespace and can be called as `emg3d.solve()`, making the main command of `emg3d` much shorter and less confusion.